### PR TITLE
Ruby 2.4: Fixnum and Bignum are unified into Integer.

### DIFF
--- a/lib/games_dice/bunch.rb
+++ b/lib/games_dice/bunch.rb
@@ -98,7 +98,7 @@ class GamesDice::Bunch
   # @return [Array<GamesDice::DieResult>, nil] Sequence of GamesDice::DieResult objects.
   def result_details
     return nil unless @raw_result_details
-    @raw_result_details.map { |r| r.is_a?(Fixnum) ? GamesDice::DieResult.new(r) : r }
+    @raw_result_details.map { |r| r.is_a?(Integer) ? GamesDice::DieResult.new(r) : r }
   end
 
   # @!attribute [r] min

--- a/lib/games_dice/die_result.rb
+++ b/lib/games_dice/die_result.rb
@@ -145,7 +145,7 @@ class GamesDice::DieResult
   end
 
   # @!visibility private
-  # all coercions simply use #value (i.e. nil or a Fixnum)
+  # all coercions simply use #value (i.e. nil or a Integer)
   def coerce(thing)
     @value.coerce(thing)
   end

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -44,9 +44,9 @@ RSpec::Matchers.define :be_valid_distribution do
     @error = nil
     if ! given.is_a?(Hash)
       @error = "distribution should be a Hash, but it is a #{given.class}"
-    elsif given.keys.any? { |k| ! k.is_a?(Fixnum) }
-      bad_key = given.keys.first { |k| ! k.is_a?(Fixnum) }
-      @error = "all keys should be Fixnums, but found '#{bad_key.inspect}' which is a #{bad_key.class}"
+    elsif given.keys.any? { |k| ! k.is_a?(Integer) }
+      bad_key = given.keys.first { |k| ! k.is_a?(Integer) }
+      @error = "all keys should be Integers, but found '#{bad_key.inspect}' which is a #{bad_key.class}"
     elsif given.values.any? { |v| ! v.is_a?(Float) }
       bad_value = given.values.find { |v| ! v.is_a?(Float) }
       @error = "all values should be Floats, but found '#{bad_value.inspect}' which is a #{bad_value.class}"


### PR DESCRIPTION
Hi, I really like this Gem! I'm using it with Ruby 2.4.2 which works great, though I noticed deprecation warnings i.e.:

`warning: constant ::Fixnum is deprecated`

This is due to [Ruby 2.4 unifying this](https://bugs.ruby-lang.org/issues/12005) under a common class Integer. I don't have much Ruby experience but I think it would be ok to change these to Integers. I ran the tests under 2.4.2 and 2.1.10 and they pass. Perhaps you could have a look at it.

PS: There are some other deprecation warnings on the spec files that I could have a go at after this, if that helps. Thanks for making this!