### PR TITLE
Code quality refinements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,3 +52,41 @@ jobs:
           ruby-version: '3.3'
           bundler-cache: true
       - run: bundle exec bundle-audit check --update
+
+  native-quality:
+    name: C ${{ matrix.check }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        check: [lint, coverage, sanitize]
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install C coverage tools
+        if: matrix.check == 'coverage'
+        run: sudo apt-get update && sudo apt-get install -y gcovr
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.4'
+          bundler-cache: true
+      - name: Show Ruby extension compiler
+        run: |
+          ruby -rrbconfig -e 'puts RbConfig::CONFIG.fetch("CC")'
+          gcc --version
+      - name: Run native quality check
+        run: bundle exec rake c:${{ matrix.check }}
+      - name: Add C coverage summary to job summary
+        if: matrix.check == 'coverage' && always()
+        run: |
+          if test -f coverage/c/summary.txt; then
+            cat coverage/c/summary.txt >> "$GITHUB_STEP_SUMMARY"
+          fi
+      - name: Upload C coverage report
+        if: matrix.check == 'coverage' && always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: c-coverage
+          path: coverage/c
+          retention-days: 14
+          if-no-files-found: warn

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,3 +41,14 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
       - run: bundle exec rubocop
+
+  audit:
+    name: Dependency audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+      - run: bundle exec bundle-audit check --update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['3.3', '3.4']
+        ruby: ['3.3', '3.4', '4.0']
     steps:
       - uses: actions/checkout@v6
       - uses: ruby/setup-ruby@v1
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['3.3', '3.4']
+        ruby: ['3.3', '3.4', '4.0']
     steps:
       - uses: actions/checkout@v6
       - uses: ruby/setup-ruby@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,11 @@ name: CI
 
 on:
   push:
+    branches:
+      - main
+  pull_request:
+  schedule:
+    - cron: '0 6 8 * *'
 
 permissions:
   contents: read
@@ -15,7 +20,7 @@ jobs:
       matrix:
         ruby: ['3.3', '3.4']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
@@ -30,7 +35,7 @@ jobs:
       matrix:
         ruby: ['3.3', '3.4']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # GamesDice Changelog
 
+## 0.5.0 ( 22 July 2026 )
+
+ * Add support and CI coverage for Ruby 4.0.
+ * Add dependency auditing and native extension lint, sanitizer, and coverage checks to CI.
+ * Modernise native probability object memory management using Ruby's typed data API.
+ * Expand probability specifications to cover native extension edge cases.
+
 ## 0.4.2 ( 19 July 2026 )
 
  * Require MRI Ruby 3.3 or later and test against Ruby 3.3 and 3.4.

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ source 'https://rubygems.org'
 # Dependencies are in games_dice.gemspec
 gemspec
 
+gem 'bundler-audit', '~> 0.9', require: false
 gem 'rake', '~> 13.2'
 gem 'rake-compiler', '~> 1.2'
 gem 'redcarpet', '~> 3.6'

--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
 require 'bundler/gem_tasks'
+require 'fileutils'
+require 'open3'
+require 'rbconfig'
 require 'rspec/core/rake_task'
 require 'rake/extensiontask'
+require 'shellwords'
 require 'yard'
 
 desc 'GamesDice unit tests'
@@ -25,3 +29,80 @@ Rake::ExtensionTask.new do |ext|
 end
 
 task default: %i[compile spec]
+
+rebuild_and_test_native = lambda do |mode, test: true|
+  tasks = %w[clobber compile]
+  tasks << 'spec' if test
+
+  sh(
+    { 'GAMES_DICE_NATIVE_MODE' => mode },
+    RbConfig.ruby,
+    '-S',
+    'bundle',
+    'exec',
+    'rake',
+    *tasks
+  )
+end
+
+# Native quality orchestration is kept together so each task shares the same rebuild contract.
+# rubocop:disable Metrics/BlockLength
+namespace :c do
+  desc 'Compile the C extension with strict warnings'
+  task :lint do
+    rebuild_and_test_native.call('lint', test: false)
+  end
+
+  desc 'Measure C coverage using the full Ruby spec suite'
+  task :coverage do
+    cc = RbConfig::CONFIG.fetch('CC')
+    compiler_version = Open3.capture2e(*Shellwords.split(cc), '--version').first
+
+    unless compiler_version.match?(/gcc/i) && !compiler_version.match?(/clang/i)
+      abort "c:coverage requires a GCC Ruby build (current compiler: #{cc})"
+    end
+
+    abort 'c:coverage requires gcovr on PATH' unless system('gcovr', '--version', out: File::NULL)
+
+    rebuild_and_test_native.call('coverage')
+
+    FileUtils.mkdir_p('coverage/c')
+    sh(
+      'gcovr',
+      '--root', '.',
+      '--filter', 'ext/games_dice/',
+      '--html-details', 'coverage/c/index.html',
+      '--xml', 'coverage/c/cobertura.xml',
+      '--txt', 'coverage/c/summary.txt',
+      '--print-summary'
+    )
+  end
+
+  desc 'Run the Ruby specs with ASan and UBSan'
+  task :sanitize do
+    abort 'c:sanitize requires Linux' unless RUBY_PLATFORM.include?('linux')
+
+    cc = RbConfig::CONFIG.fetch('CC')
+    compiler_version = Open3.capture2e(*Shellwords.split(cc), '--version').first
+
+    unless compiler_version.match?(/gcc/i) && !compiler_version.match?(/clang/i)
+      abort "c:sanitize requires a GCC Ruby build (current compiler: #{cc})"
+    end
+
+    libasan = Open3.capture2e(*Shellwords.split(cc), '-print-file-name=libasan.so').first.strip
+    abort 'c:sanitize could not locate the GCC ASan runtime' if libasan.empty? || libasan == 'libasan.so'
+
+    rebuild_and_test_native.call('sanitize', test: false)
+
+    sh(
+      { 'ASAN_OPTIONS' => 'detect_leaks=0', 'LD_PRELOAD' => libasan },
+      RbConfig.ruby,
+      '-S',
+      'bundle',
+      'exec',
+      'rake',
+      'spec'
+    )
+  end
+end
+# rubocop:enable Metrics/BlockLength

--- a/ext/games_dice/extconf.rb
+++ b/ext/games_dice/extconf.rb
@@ -3,5 +3,34 @@
 # ext/games_dice/extconf.rb
 
 require 'mkmf'
+require 'rbconfig'
+
+# mkmf exposes compiler and linker flags through these globals.
+# rubocop:disable Style/GlobalVars
+case ENV.fetch('GAMES_DICE_NATIVE_MODE', 'release')
+when 'release'
+  # Use Ruby's normal extension build flags.
+when 'lint'
+  $CFLAGS << ' -std=gnu2x -O0 -g'
+  $CFLAGS << ' -Wall -Wextra -Wpedantic -Wformat=2 -Werror'
+
+  cc = RbConfig::CONFIG.fetch('CC')
+  host_os = RbConfig::CONFIG.fetch('host_os')
+  if cc.include?('clang') || host_os.include?('darwin')
+    # Ruby callback signatures legitimately leave some parameters unused, and
+    # Ruby 4 headers use standard attributes that Clang treats as C23 syntax.
+    $CFLAGS << ' -Wno-strict-prototypes -Wno-unused-parameter -Wno-c23-extensions'
+  end
+when 'coverage'
+  $CFLAGS << ' -O0 -g --coverage'
+  $LDFLAGS << ' --coverage'
+when 'sanitize'
+  $CFLAGS << ' -O1 -g -fsanitize=address,undefined'
+  $CFLAGS << ' -fno-omit-frame-pointer'
+  $LDFLAGS << ' -fsanitize=address,undefined'
+else
+  abort "Unknown GAMES_DICE_NATIVE_MODE: #{ENV.fetch('GAMES_DICE_NATIVE_MODE', nil)}"
+end
+# rubocop:enable Style/GlobalVars
 
 create_makefile('games_dice/games_dice')

--- a/ext/games_dice/games_dice.c
+++ b/ext/games_dice/games_dice.c
@@ -6,7 +6,7 @@
 // To hold the module object
 VALUE GamesDice = Qnil;
 
-void Init_games_dice() {
+void Init_games_dice(void) {
   GamesDice = rb_define_module("GamesDice");
   init_probabilities_class();
 }

--- a/ext/games_dice/probabilities.c
+++ b/ext/games_dice/probabilities.c
@@ -21,7 +21,7 @@ VALUE Probabilities = Qnil;
 //  General utils
 //
 
-inline int max( int *a, int n ) {
+static int max( int *a, int n ) {
   int m = -1000000000;
   int i;
   for ( i=0; i < n; i++ ) {
@@ -30,7 +30,7 @@ inline int max( int *a, int n ) {
   return m;
 }
 
-inline int min( int *a, int n ) {
+static int min( int *a, int n ) {
   int m = 1000000000;
   int i;
   for ( i=0; i < n; i++ ) {
@@ -110,7 +110,7 @@ double num_arrangements( int *args, int nargs ) {
 //  Probability List basics - create, delete, copy
 //
 
-ProbabilityList *create_probability_list() {
+ProbabilityList *create_probability_list(void) {
   ProbabilityList *pl;
   pl = malloc (sizeof(ProbabilityList));
   if ( pl == NULL ) {
@@ -183,7 +183,7 @@ ProbabilityList *copy_probability_list( ProbabilityList *orig ) {
   return pl;
 }
 
-inline ProbabilityList *new_basic_pl( int nslots, double iv, int o ) {
+static ProbabilityList *new_basic_pl( int nslots, double iv, int o ) {
   ProbabilityList *pl = create_probability_list();
   alloc_probs_iv( pl, nslots, iv );
   pl->offset = o;
@@ -195,11 +195,13 @@ inline ProbabilityList *new_basic_pl( int nslots, double iv, int o ) {
 //  Probability List core "native" methods
 //
 
-inline int pl_min( ProbabilityList *pl ) {
+static double pl_p_le( ProbabilityList *pl, int target );
+
+static int pl_min( ProbabilityList *pl ) {
   return pl->offset;
 }
 
-inline int pl_max( ProbabilityList *pl ) {
+static int pl_max( ProbabilityList *pl ) {
   return pl->offset + pl->slots - 1;
 }
 
@@ -243,7 +245,7 @@ ProbabilityList *pl_add_distributions_mult( int mul_a, ProbabilityList *pl_a, in
   return pl;
 }
 
-inline double pl_p_eql( ProbabilityList *pl, int target ) {
+static double pl_p_eql( ProbabilityList *pl, int target ) {
   int idx = target - pl->offset;
   if ( idx < 0 || idx >= pl->slots ) {
     return 0.0;
@@ -251,15 +253,15 @@ inline double pl_p_eql( ProbabilityList *pl, int target ) {
   return (pl->probs)[idx];
 }
 
-inline double pl_p_gt( ProbabilityList *pl, int target ) {
+static double pl_p_gt( ProbabilityList *pl, int target ) {
   return 1.0 - pl_p_le( pl, target );
 }
 
-inline double pl_p_lt( ProbabilityList *pl, int target ) {
+static double pl_p_lt( ProbabilityList *pl, int target ) {
   return pl_p_le( pl, target - 1 );
 }
 
-inline double pl_p_le( ProbabilityList *pl, int target ) {
+static double pl_p_le( ProbabilityList *pl, int target ) {
   int idx = target - pl->offset;
   if ( idx < 0 ) {
     return 0.0;
@@ -270,11 +272,11 @@ inline double pl_p_le( ProbabilityList *pl, int target ) {
   return (pl->cumulative)[idx];
 }
 
-inline double pl_p_ge( ProbabilityList *pl, int target ) {
+static double pl_p_ge( ProbabilityList *pl, int target ) {
   return 1.0 - pl_p_le( pl, target - 1 );
 }
 
-inline double pl_expected( ProbabilityList *pl ) {
+static double pl_expected( ProbabilityList *pl ) {
   double t = 0.0;
   int o = pl->offset;
   int s = pl->slots;
@@ -426,7 +428,7 @@ void calc_keep_distributions( ProbabilityList *pl, int k, int q, int kbest, Prob
   return;
 }
 
-inline void clear_pl_array( int k, ProbabilityList **pl_array  ) {
+static void clear_pl_array( int k, ProbabilityList **pl_array  ) {
   int n;
   for ( n=0; n<k; n++) {
     if ( pl_array[n] != NULL ) {
@@ -515,23 +517,50 @@ ProbabilityList *pl_repeat_n_sum_k( ProbabilityList *pl, int n, int k, int kbest
 //  Ruby integration
 //
 
-inline VALUE pl_as_ruby_class( ProbabilityList *pl, VALUE klass ) {
-  return Data_Wrap_Struct( klass, 0, destroy_probability_list, pl );
+static void free_probability_list( void *ptr ) {
+  destroy_probability_list( ptr );
+}
+
+static size_t probability_list_memsize( const void *ptr ) {
+  const ProbabilityList *pl = ptr;
+  size_t size = sizeof(ProbabilityList);
+
+  if ( pl == NULL ) return 0;
+  if ( pl->probs != NULL ) size += pl->slots * sizeof(double);
+  if ( pl->cumulative != NULL ) size += pl->slots * sizeof(double);
+  return size;
+}
+
+static const rb_data_type_t probability_list_type = {
+  .wrap_struct_name = "GamesDice::Probabilities",
+  .function = {
+    .dmark = NULL,
+    .dfree = free_probability_list,
+    .dsize = probability_list_memsize,
+    .dcompact = NULL,
+    .reserved = { NULL }
+  },
+  .parent = NULL,
+  .data = NULL,
+  .flags = 0
+};
+
+static inline VALUE pl_as_ruby_class( ProbabilityList *pl, VALUE klass ) {
+  return TypedData_Wrap_Struct( klass, &probability_list_type, pl );
 }
 
 VALUE pl_alloc(VALUE klass) {
   return pl_as_ruby_class( create_probability_list(), klass );
 }
 
-inline ProbabilityList *get_probability_list( VALUE obj ) {
+static inline ProbabilityList *get_probability_list( VALUE obj ) {
   ProbabilityList *pl;
-  Data_Get_Struct( obj, ProbabilityList, pl );
+  TypedData_Get_Struct( obj, ProbabilityList, &probability_list_type, pl );
   return pl;
 }
 
 void assert_value_wraps_pl( VALUE obj ) {
-  if ( TYPE(obj) != T_DATA ||
-      RDATA(obj)->dfree != (RUBY_DATA_FUNC)destroy_probability_list) {
+  if ( ! rb_typeddata_is_kind_of( obj, &probability_list_type ) ) {
     rb_raise( rb_eTypeError, "Expected a Probabilities object, but got something else" );
   }
 }
@@ -887,8 +916,9 @@ VALUE probabilities_from_h( VALUE self, VALUE hash ) {
  *   @return [GamesDice::Probabilities]
  */
 VALUE probabilities_add_distributions( VALUE self, VALUE gdpa, VALUE gdpb ) {
-  ProbabilityList *pl_a = get_probability_list( gdpa );
-  ProbabilityList *pl_b = get_probability_list( gdpb );
+  ProbabilityList *pl_a;
+  ProbabilityList *pl_b;
+
   assert_value_wraps_pl( gdpa );
   assert_value_wraps_pl( gdpb );
   pl_a = get_probability_list( gdpa );
@@ -925,7 +955,7 @@ VALUE probabilities_add_distributions_mult( VALUE self, VALUE m_a, VALUE gdpa, V
 //  Setup Probabilities class for Ruby interpretter
 //
 
-void init_probabilities_class() {
+void init_probabilities_class(void) {
   VALUE GamesDice = rb_define_module("GamesDice");
   Probabilities = rb_define_class_under( GamesDice, "Probabilities", rb_cObject );
   rb_define_alloc_func( Probabilities, pl_alloc );

--- a/ext/games_dice/probabilities.h
+++ b/ext/games_dice/probabilities.h
@@ -7,7 +7,7 @@
 
 #include <ruby.h>
 
-void init_probabilities_class();
+void init_probabilities_class(void);
 
 typedef struct _pd {
     int offset;
@@ -16,25 +16,9 @@ typedef struct _pd {
     double *cumulative;
   } ProbabilityList;
 
-inline int pl_min( ProbabilityList *pl );
-
-inline int pl_max( ProbabilityList *pl );
-
 ProbabilityList *pl_add_distributions( ProbabilityList *pl_a, ProbabilityList *pl_b );
 
 ProbabilityList *pl_add_distributions_mult( int mul_a, ProbabilityList *pl_a, int mul_b, ProbabilityList *pl_b );
-
-inline double pl_p_eql( ProbabilityList *pl, int target );
-
-inline double pl_p_gt( ProbabilityList *pl, int target );
-
-inline double pl_p_lt( ProbabilityList *pl, int target );
-
-inline double pl_p_le( ProbabilityList *pl, int target );
-
-inline double pl_p_ge( ProbabilityList *pl, int target );
-
-inline double pl_expected( ProbabilityList *pl );
 
 ProbabilityList *pl_given_ge( ProbabilityList *pl, int target );
 

--- a/lib/games_dice/version.rb
+++ b/lib/games_dice/version.rb
@@ -2,5 +2,5 @@
 
 module GamesDice
   # Current version of the gem.
-  VERSION = '0.4.2'
+  VERSION = '0.5.0'
 end

--- a/spec/probability_spec.rb
+++ b/spec/probability_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'helpers'
+require 'objspace'
 
 describe GamesDice::Probabilities do
   describe 'class methods' do
@@ -23,6 +24,7 @@ describe GamesDice::Probabilities do
         expect { described_class.new([], 1) }.to raise_error ArgumentError
         expect { described_class.new([0.9], 1) }.to raise_error ArgumentError
         expect { described_class.new([-0.9, 0.2, 0.9], 1) }.to raise_error ArgumentError
+        expect { described_class.new([1.1], 1) }.to raise_error ArgumentError
       end
     end
 
@@ -143,8 +145,14 @@ describe GamesDice::Probabilities do
         expect(pr).to be_a described_class
       end
 
+      it 'create the same distribution when hash keys descend' do
+        pr = described_class.from_h({ 9 => 0.5, 7 => 0.5 })
+        expect(pr.to_h).to eql({ 7 => 0.5, 9 => 0.5 })
+      end
+
       it 'raise an ArgumentError when called with a non-valid hash' do
         expect { described_class.from_h({ 7 => 0.5, 9 => 0.6 }) }.to raise_error ArgumentError
+        expect { described_class.from_h({ 7 => 0.4, 9 => 0.5 }) }.to raise_error ArgumentError
       end
 
       it 'raise an TypeError when called with data that is not a hash' do
@@ -168,6 +176,21 @@ describe GamesDice::Probabilities do
     let(:pr6) { described_class.for_fair_die(6) }
     let(:pr10) { described_class.for_fair_die(10) }
     let(:pra) { described_class.new([0.4, 0.2, 0.4], -1) }
+
+    describe '#clone' do
+      it 'create an independent object with the same distribution' do
+        copy = pra.clone
+        expect(copy).not_to equal(pra)
+        expect(copy.to_h).to eql(pra.to_h)
+      end
+    end
+
+    describe 'native memory accounting' do
+      it 'include allocated probability arrays' do
+        empty = described_class.allocate
+        expect(ObjectSpace.memsize_of(pr10)).to be > ObjectSpace.memsize_of(empty)
+      end
+    end
 
     describe '#each' do
       it 'iterate through all result/probability pairs' do
@@ -375,6 +398,11 @@ describe GamesDice::Probabilities do
       it 'raise a TypeError if asked for probability of non-Integer' do
         expect { pr10.given_ge([]) }.to raise_error TypeError
       end
+
+      it 'clamp targets below the minimum and reject targets above the maximum' do
+        expect(pr10.given_ge(0).to_h).to eql(pr10.to_h)
+        expect { pr10.given_ge(11) }.to raise_error(RuntimeError, /divide by zero/)
+      end
     end
 
     describe '#given_le' do
@@ -389,6 +417,11 @@ describe GamesDice::Probabilities do
 
       it 'raise a TypeError if asked for probability of non-Integer' do
         expect { pr10.given_le({}) }.to raise_error TypeError
+      end
+
+      it 'clamp targets above the maximum and reject targets below the minimum' do
+        expect(pr10.given_le(11).to_h).to eql(pr10.to_h)
+        expect { pr10.given_le(0) }.to raise_error(RuntimeError, /divide by zero/)
       end
     end
 
@@ -405,6 +438,10 @@ describe GamesDice::Probabilities do
       it 'raise an error if any param is unexpected type' do
         d6 = described_class.for_fair_die(6)
         expect { d6.repeat_sum({}) }.to raise_error TypeError
+      end
+
+      it 'raise an error if repetitions are not positive' do
+        expect { pr6.repeat_sum(0) }.to raise_error(RuntimeError, /n < 1/)
       end
 
       it 'raise an error if distribution would have more than a million results' do
@@ -450,6 +487,24 @@ describe GamesDice::Probabilities do
         d6 = described_class.for_fair_die(6)
         expect { d6.repeat_n_sum_k({}, 10) }.to raise_error TypeError
         expect { d6.repeat_n_sum_k(10, {}) }.to raise_error TypeError
+      end
+
+      it 'raise an error if repetitions or keepers are not positive' do
+        expect { pr6.repeat_n_sum_k(0, 1) }.to raise_error(RuntimeError, /n < 1/)
+        expect { pr6.repeat_n_sum_k(2, 0) }.to raise_error(RuntimeError, /k < 1/)
+      end
+
+      it 'sum every repetition when the keeper count is at least the repetition count' do
+        expect(pr6.repeat_n_sum_k(3, 3).to_h).to eql(pr6.repeat_sum(3).to_h)
+      end
+
+      it 'raise an error if the kept distribution would have more than a million results' do
+        d1000 = described_class.for_fair_die(1000)
+        expect { d1000.repeat_n_sum_k(1003, 1002) }.to raise_error(RuntimeError, /Too many probability slots/)
+      end
+
+      it 'raise an error for an unknown keep mode' do
+        expect { pr6.repeat_n_sum_k(3, 2, :middle) }.to raise_error(ArgumentError, /Keep mode/)
       end
 
       it 'raise an error if n is greater than 170' do
@@ -505,6 +560,13 @@ describe GamesDice::Probabilities do
         expect(h[18]).to be_within(1e-10).of 5 / 400.0
         expect(h[19]).to be_within(1e-10).of 3 / 400.0
         expect(h[20]).to be_within(1e-10).of 1 / 400.0
+      end
+
+      it "calculate a '4d6 keep worst 3' distribution accurately at its bounds" do
+        h = pr6.repeat_n_sum_k(4, 3, :keep_worst).to_h
+        expect(h).to be_valid_distribution
+        expect(h[3]).to be_within(1e-10).of 21 / 1296.0
+        expect(h[18]).to be_within(1e-10).of 1 / 1296.0
       end
     end
   end


### PR DESCRIPTION
## Summary

- modernise the native probability extension using Ruby’s typed data API
- add native C linting, sanitizer checks, and GCC coverage reporting
- expand probability specs, reaching 99.3% line, 100% function, and 95.8% branch coverage for `probabilities.c`
- add dependency auditing to CI
- test RSpec and RuboCop against Ruby 3.3, 3.4, and 4.0
- bump the gem version to 0.5.0 and update the changelog

## Testing

- `bundle exec rake` — 224 examples, 0 failures
- `bundle exec rubocop` — no offenses
- `bundle exec rake c:lint`
- `bundle exec rake c:coverage`
- `bundle exec rake c:sanitize`
- `bundle exec bundle-audit check --update`
- `bundle exec rake build` — built `games_dice-0.5.0.gem`